### PR TITLE
Fix babel setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-    "presets": [
-        "@babel/preset-env"
-    ]
-}

--- a/babel-wrapper.cjs
+++ b/babel-wrapper.cjs
@@ -1,0 +1,3 @@
+module.exports = require('babel-jest').createTransformer({
+  rootMode: 'upward'
+});

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ]
+  ]
+}

--- a/jest.config.json
+++ b/jest.config.json
@@ -2,8 +2,8 @@
   "collectCoverage": true,
   "moduleFileExtensions": ["js", "mjs"],
   "transform": {
-    "^.+\\.js$": "babel-jest",
-    "^.+\\.mjs$": "babel-jest"
+    "^.+\\.js$": "./babel-wrapper.cjs",
+    "^.+\\.mjs$": "./babel-wrapper.cjs"
   },
 
   "testRegex": "((\\.|/*.)(spec))\\.js?$"


### PR DESCRIPTION
I tried a lot of combinations of configs but in the end this doc helped me https://babeljs.io/docs/en/config-files#jest

You need to set you babel mode to 'upwards' so that it uses the root config in every sub package. However, this is a babel runtime options so cant be set in the babel config. So thats why we have to create a babelWrapper file that basically just wraps babel-jest but then sets the rootMode and exports it. 

Note that its called .cjs, this is important to tell node that its a common js file.

Also with the rootMode being upwards babel decides not to support the `.babelrc` filename so i had to change it to `babel.config.json`. 🤷 

Lastly I added a target to the babel config, this just means you can use all the latest node features in your tests. 

The tests fail, but seems like a legit failure to me